### PR TITLE
devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+RUN apt-get update && \
+    apt-get -y install python3 python3-venv redis firefox-esr graphviz imagemagick librsvg2-bin fonts-dejavu shellcheck

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-azuretools.vscode-docker"
+      ],
+      "remote.otherPortsAttributes": {          
+        "protocol": "https"
+      },
+      "settings": {
+        "files.autoSave": "off"
+      }
+    }
+  },
+	"postCreateCommand": "git pull"
+}


### PR DESCRIPTION
devcontainer是codespace的预配置环境，在codespace initialize阶段安装配置必要的环境。

目前的初始化配置
- python3
- vscode  extension: mspython